### PR TITLE
Allow options to have underscores

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -673,7 +673,7 @@ def get_click_param(
             # Click doesn't accept a flag of type bool, only None, and then it sets it
             # to bool internally
             parameter_type = None
-        default_option_name = get_command_name(param.name)
+        default_option_name = name.lower()
         if is_flag:
             default_option_declaration = (
                 f"--{default_option_name}/--no-{default_option_name}"


### PR DESCRIPTION
Instead of always replacing with dashes